### PR TITLE
MERGE bugfix/23-fix-chat-history-in-retrieval-chat INTO development

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.14
+### Fixed
+  - bugfix/23-fix-chat-history-in-retrieval-chat (2023-12-02)
+
 ## 0.1.13
 ### Added
   - feature/18-add-get-controller-to-retrieval-routes (2023-12-1)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = os.environ.get('VERSION', '0.0.1') 
+VERSION = os.environ.get('VERSION', '0.1.13') 
 
 setup(
     name='promptengineers',


### PR DESCRIPTION
Closes #23 
---
The file changes for Pull Request #24 titled "MERGE bugfix/23-fix-chat-history-in-retrieval-chat INTO development" in the promptengineers-ai/core repository include modifications to the following files:

Changelog.md - This file has been modified, and the patch summary indicates that there have been 4 additions. The changes include:

A new section for version 0.1.14 has been added under the changelog.
Mentions "Fixed" with the following detail: "bugfix/23-fix-chat-history-in-retrieval-chat (2023-12-02)".
View [Changelog.md changes](https://github.com/promptengineers-ai/core/blob/3c38ffe59459bdb9bc3b546adcb11a0df1bdadf4/Changelog.md)

setup.py - This file has also been modified, and the patch summary shows there is 1 addition and 1 deletion, which amounts to 2 changes overall. The changes include:

The version in the setup.py file has been updated to 0.1.13.
View [setup.py changes](https://github.com/promptengineers-ai/core/blob/3c38ffe59459bdb9bc3b546adcb11a0df1bdadf4/setup.py)

These changes seem to be for a new version release, updating the changelog and the package version in the setup file