### PR TITLE
Remove locked versions for openai and langchain in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ setup(
             'beautifulsoup4',
         ],
         'retrieval': [
-            'langchain==0.0.275',
-            'openai==0.27.8',
+            'langchain',
+            'openai',
             'python-multipart',
             'redis',
             'pinecone-client',


### PR DESCRIPTION
This PR removes the locked versions for `openai` and `langchain` in the `setup.py` file. This change will allow for more flexible installation of these packages.

Closes #31