### PR TITLE
Remove locked versions from openai and langchain

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ setup(
             'beautifulsoup4',
         ],
         'retrieval': [
-            'langchain==0.0.275',
-            'openai==0.27.8',
+            'langchain',
+            'openai',
             'python-multipart',
             'redis',
             'pinecone-client',


### PR DESCRIPTION
This pull request removes the locked versions for `openai` and `langchain` in `setup.py` file to ensure flexibility in installing newer versions of these packages.

Closes #33