### PR TITLE
Unlock openai and langchain versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ setup(
             'beautifulsoup4',
         ],
         'retrieval': [
-            'langchain==0.0.275',
-            'openai==0.27.8',
+            'langchain',
+            'openai',
             'python-multipart',
             'redis',
             'pinecone-client',


### PR DESCRIPTION
This pull request removes the locked versions from `openai` and `langchain` in the `setup.py` file to allow for more flexibility in dependency management.

Closes #35