### PR TITLE
MERGE feature/37-unlock-dependency-versions INTO master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ setup(
             'beautifulsoup4',
         ],
         'retrieval': [
-            'langchain==0.0.275',
-            'openai==0.27.8',
+            'langchain',
+            'openai',
             'python-multipart',
             'redis',
             'pinecone-client',


### PR DESCRIPTION
This pull request is to merge changes from `feature/37-unlock-dependency-versions` into `master`. It addresses the task of removing the locked versions from `openai` and `langchain` dependencies in the `setup.py` file.

Closes #37